### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Python package
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/se2026/special-funicular/security/code-scanning/5](https://github.com/se2026/special-funicular/security/code-scanning/5)

To fix the problem, add a `permissions` key at the appropriate level of the workflow YAML configuration to limit the `GITHUB_TOKEN` permissions granted to this job/workflow. Since the workflow contains a single job named `build`, the `permissions` key can be added either at the root level (to apply to all jobs) or under the `build` job (to apply only to that job). The minimal permission required for running local Python tests and lint is `contents: read`, which allows steps like checkout to succeed but prevents write permissions. The best way to fix is to add a `permissions:` block with `contents: read` directly below the `name:` field (i.e., at the workflow root), before the `on:` block. No additional imports or methods are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
