### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,6 +7,8 @@
 # documentation.
 
 name: Java CI with Maven
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/se2026/special-funicular/security/code-scanning/1](https://github.com/se2026/special-funicular/security/code-scanning/1)

To fix the problem, we should explicitly add a `permissions` key to either the root of the workflow (applies to all jobs by default) or to the affected job (`build`). The minimal permissions required for a typical Maven CI workflow are `contents: read`; this allows jobs to check out code, but not perform any unwanted writes. If additional steps require more permissions, such as submitting dependency graphs, those specific permissions (such as `security-events: write` for the dependency submission) should be added per job. In this case, adding the following to either the root (just after `name:`) or to the `build` job block is appropriate:

```yaml
permissions:
  contents: read
```

If the dependency submission step requires additional permissions (e.g., `security-events: write`), you can also include that:

```yaml
permissions:
  contents: read
  security-events: write
```

It's best to start with a minimal block and expand if GitHub indicates insufficient permission errors.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
