### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,9 @@ name: Pylint
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/se2026/special-funicular/security/code-scanning/4](https://github.com/se2026/special-funicular/security/code-scanning/4)

To fix this problem, we should add an explicit `permissions` block to the workflow to limit the `GITHUB_TOKEN`'s privileges to the minimal necessary for the tasks in this workflow. Since this workflow performs a checkout (which only requires `contents: read`), installs Python, and runs pylint—without making changes or writing to the repository or opening issues—`contents: read` is sufficient. The best practice is to add this at the top/root of the workflow (before the `jobs:` block), so all jobs inherit it, unless jobs require different permissions. Edit `.github/workflows/pylint.yml` by inserting:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `jobs:` block (i.e., after line 4, before line 5). No other code, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
