### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -1,4 +1,6 @@
 name: Django CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/se2026/special-funicular/security/code-scanning/2](https://github.com/se2026/special-funicular/security/code-scanning/2)

The best way to fix the problem is to add an explicit `permissions` block to the workflow or the relevant job, specifying only the necessary permissions for the tasks being performed. As the job does not need any write or administrative privileges (just code checkout and running tests), setting the permission to `contents: read` is sufficient and in line with the principle of least privilege. The `permissions` key can be set at the workflow root to apply to all jobs, or within the specific job block. Here, adding it at the workflow root just below the workflow name (line 2) will ensure all jobs inherit these minimal permissions. No other methods, imports, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
