### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -1,6 +1,8 @@
 name: Python Package using Conda
 
 on: [push]
+permissions:
+  contents: read
 
 jobs:
   build-linux:


### PR DESCRIPTION
Potential fix for [https://github.com/se2026/special-funicular/security/code-scanning/3](https://github.com/se2026/special-funicular/security/code-scanning/3)

To fix the problem, you should add a `permissions` block to the workflow (preferably at the root level, before the `jobs:` key) assigning only the minimal permissions required for the workflow to run—typically, that means `contents: read` for a testing/linting workflow that only checks out code (and does not need to write anything to the repository, open PRs, or manage issues). No existing functionality will change. The only change required is to insert a `permissions:` block after the `name:` and `on:` keys, before `jobs:`. No new imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
